### PR TITLE
Issue/30 - password helper text

### DIFF
--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -40,7 +40,7 @@
     />
     
     {#if text && !error}
-        <p class="" data-testid={`${id}-text`}>{text}</p>
+        <p class="input-text" data-testid={`${id}-text`}>{text}</p>
     {/if}
 
     {#if error}
@@ -67,7 +67,7 @@
     p {
         margin: 0;
 
-        &:not(.error) {
+        &.input-text {
             color: var(--dark-900);
             line-height: 1rem;
         }

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -40,7 +40,7 @@
     />
     
     {#if text && !error}
-        <p data-testid={`${id}-text`}>{text}</p>
+        <p class="" data-testid={`${id}-text`}>{text}</p>
     {/if}
 
     {#if error}
@@ -69,7 +69,7 @@
 
         &:not(.error) {
             color: var(--dark-900);
-            line-height: 0.8rem;
+            line-height: 1rem;
         }
     }
 

--- a/src/lib/components/forms/Signup.svelte
+++ b/src/lib/components/forms/Signup.svelte
@@ -172,7 +172,7 @@
         id="password"
         type="password"
         label="Password"
-        text="this is just a test"
+        text="Must be at least 8 characters long and contain at least one number, one uppercase letter, one lowercase letter, and one special character."
         placeholder="Enter your password"
         error={passwordError}
         on:blur={onPasswordBlur}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -52,6 +52,9 @@ test('sign up form has username, email, password, and confirm password fields', 
     const passwordField = await signUpForm.getByLabel('Password', { exact: true });
     await expect(passwordField).toBeVisible();
 
+    const passwordText = await signUpForm.getByText('Must be at least 8 characters long and contain at least one number, one uppercase letter, one lowercase letter, and one special character.', { exact: true });
+    await expect(passwordText).toBeVisible();
+
     const confirmPasswordField = await signUpForm.getByLabel('Confirm password');
     await expect(confirmPasswordField).toBeVisible();
 })


### PR DESCRIPTION
Resolves #30 

Updates the helper text of the password filed in the sign up form with instructions on what the password restraints are.