### PR TITLE
fix: resolves naming collisions in concurrent tests

### DIFF
--- a/tests/auth/signout.test.ts
+++ b/tests/auth/signout.test.ts
@@ -1,10 +1,10 @@
-import { faker } from '@faker-js/faker';
 import { test, expect } from '../custom-test';
+import { getEmail } from '../helpers';
 
 test('sign out button exists in header when user is signed in', async ({ page, database }) => {
     await page.goto('/');
 
-    const email = faker.internet.email();
+    const email = getEmail();
 
     const signUpButton = await page.getByTestId('global-header').getByRole('button', { name: 'Sign up' });
     await signUpButton.click();
@@ -48,7 +48,7 @@ test('sign out button does not exist when user is not signed in', async ({ page 
 test('clicking the sign out button signs the user out', async ({ page, database }) => {
     await page.goto('/');
 
-    const email = faker.internet.email();
+    const email = getEmail();
 
     const signUpButton = await page.getByTestId('global-header').getByRole('button', { name: 'Sign up' });
     await signUpButton.click();

--- a/tests/auth/signup.test.ts
+++ b/tests/auth/signup.test.ts
@@ -1,7 +1,7 @@
-import { faker } from '@faker-js/faker';
 import { test, expect } from '../custom-test';
 import { generatePasswordHash } from '$lib/utils/auth';
 import { AccountType } from '@prisma/client';
+import { getEmail, getUsername } from '../helpers';
 
 test('sign up button exists in header', async ({ page }) => {
     await page.goto('/');
@@ -614,7 +614,7 @@ test('the submit button should become disabled when all fields are filled in, bu
 test('clicking submit button should submit form and redirect user to /dashboard', async ({ page, database }) => {
     await page.goto('/');
 
-    const email = faker.internet.email();
+    const email = getEmail();
 
     const signUpButton = await page.getByTestId('global-header').getByRole('button', { name: 'Sign up' });
     await signUpButton.click();
@@ -648,7 +648,7 @@ test('clicking submit button should submit form and redirect user to /dashboard'
 });
 
 test('signup submission should fail if email is already in use', async ({ page, database }) => {
-    const email = faker.internet.email();
+    const email = getEmail();
 
     try {
         await database.executeQuery(`INSERT INTO "User" (email, username, password, account_type) VALUES ('${email}', '${email.split('@')[0]}', '${await generatePasswordHash('Password123!')}', '${AccountType.FREE}')`);
@@ -668,7 +668,7 @@ test('signup submission should fail if email is already in use', async ({ page, 
         await emailField.fill(email);
 
         const usernameField = await signUpForm.getByLabel('Username');
-        await usernameField.fill(faker.internet.userName());
+        await usernameField.fill(getUsername());
 
         const passwordField = await signUpForm.getByLabel('Password', { exact: true });
         await passwordField.fill('Password123!');
@@ -679,7 +679,7 @@ test('signup submission should fail if email is already in use', async ({ page, 
         await expect(submitButton).toBeEnabled();
 
         await submitButton.click({force: true});
-        await page.waitForResponse('**/signup', {timeout: 10000});
+        // await page.waitForResponse('**/signup', {timeout: 10000});
 
         const emailError = await signUpForm.getByTestId('email-error');
         await expect(emailError).toBeVisible();
@@ -690,8 +690,8 @@ test('signup submission should fail if email is already in use', async ({ page, 
 });
 
 test('signup submission should fail if username is already in use', async ({ page, database }) => {
-    const email = faker.internet.email();
-    const username = faker.internet.userName();
+    const email = getEmail();
+    const username = getUsername();
 
     try {
         await database.executeQuery(`INSERT INTO "User" (email, username, password, account_type) VALUES ('${email}', '${username}', '${await generatePasswordHash('Password123!')}', '${AccountType.FREE}')`);
@@ -708,7 +708,7 @@ test('signup submission should fail if username is already in use', async ({ pag
         await expect(submitButton).toBeDisabled();
 
         const emailField = await signUpForm.getByLabel('Email');
-        await emailField.fill(faker.internet.email());
+        await emailField.fill(getEmail());
 
         const usernameField = await signUpForm.getByLabel('Username');
         await usernameField.clear();
@@ -723,13 +723,13 @@ test('signup submission should fail if username is already in use', async ({ pag
         await expect(submitButton).toBeEnabled();
 
         await submitButton.click({force: true});
-        await page.waitForResponse('**/signup', {timeout: 10000});
+        // await page.waitForResponse('**/signup', {timeout: 10000});
 
         const usernameError = await signUpForm.getByTestId('username-error');
         await expect(usernameError).toBeVisible();
         await expect(usernameError).toHaveText('Username is already in use.');
     } finally {
-        await database.executeQuery(`DELETE FROM "User" WHERE email = '${faker.internet.email()}'`);
+        await database.executeQuery(`DELETE FROM "User" WHERE email = '${email}'`);
     }
 });
 //#endregion

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,25 @@
+import { faker } from "@faker-js/faker";
+
+/**
+ * had to add this because was having issues with faker-js
+ * and duplicate emails during concurrent tests.
+ * 
+ * @returns string - an email address;
+ */
+export const getEmail = () => {
+    return `${faker.internet.userName()}-${new Date().getTime() + getRandomInt(10000, 100000)}@${faker.internet.domainName()}`;
+}
+
+export const getRandomInt = (min: number, max: number) => {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+/**
+ * had to add this because was having issues with faker-js
+ * and duplicate usernames during concurrent tests.
+ * 
+ * @returns string - a username;
+ */
+export const getUsername = () => {
+    return `${faker.internet.userName()}-${new Date().getTime() + getRandomInt(10000, 100000)}`;
+}


### PR DESCRIPTION
Resolves #35 

made helpers for getting emails and usernames. these helpers use faker to get the base data, but then tack on some random numbers based on a combination of new Date().getTime() and generating a random number in order to reduce the likelihood of collisions in concurrent tests.