### PR TITLE
Issue/92 is active task

### DIFF
--- a/prisma/migrations/20240209140302_add_is_active_to_tasks/migration.sql
+++ b/prisma/migrations/20240209140302_add_is_active_to_tasks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Task {
   projectId     Int?          @map("project_id")
   project       Project?      @relation(fields: [projectId], references: [id])
   projectOrder  Float?        @map("project_order")
+  isActive      Boolean       @default(true) @map("is_active")
   createdAt     DateTime      @default(now()) @db.Timestamp(6) @map("created_at")
   updatedAt     DateTime      @default(now()) @db.Timestamp(6) @map("updated_at")
 }


### PR DESCRIPTION
Supports #84 
Supports #91 
Resolves #92 

Adds `is_active` to Tasks and updates the task service to use it.

The task service will now only return active tasks by default, though there is an override to include inactive tasks as well (this will be used later). it also supports updating a task to be active/inactive, which will be used later within projects.