### PR TITLE
refactor: adds setting of max length for task title in schema

### DIFF
--- a/prisma/migrations/20240219223026_set_task_title_max_length/migration.sql
+++ b/prisma/migrations/20240219223026_set_task_title_max_length/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `title` on the `Task` table. The data in that column could be lost. The data in that column will be cast from `Text` to `VarChar(125)`.
+
+*/
+-- AlterTable
+ALTER TABLE "Task" ALTER COLUMN "title" SET DATA TYPE VARCHAR(125);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,7 +52,7 @@ model Project {
 
 model Task {
   id            Int           @id @default(autoincrement())
-  title         String
+  title         String        @db.VarChar(125)
   description   String?       @db.VarChar(3000)
   dueDate       DateTime?     @db.Timestamp(6) @map("due_date")
   completed     Boolean       @default(false)

--- a/src/lib/constants/task.ts
+++ b/src/lib/constants/task.ts
@@ -1,2 +1,2 @@
-export const MAX_TASK_TITLE_LENGTH = 100;
+export const MAX_TASK_TITLE_LENGTH = 125;
 export const MAX_TASK_DESCRIPTION_LENGTH = 3000;


### PR DESCRIPTION
Resolves #149 

Sets max length to task titles.