### PR TITLE
feat: adds no tasks found messaging when a context page has no tasks

### DIFF
--- a/src/lib/components/TaskList.svelte
+++ b/src/lib/components/TaskList.svelte
@@ -8,6 +8,8 @@
 <div class="task-list-container">
     {#each tasks as task (task.id)}
         <TaskListItem {task} />
+    {:else}
+        <p class="no-tasks" data-testid="no-tasks">No tasks found</p>
     {/each}
 </div>
 
@@ -17,5 +19,11 @@
         flex-direction: column;
         gap: 0.75rem;
         padding: 0.5rem;
+    }
+
+    .no-tasks {
+        padding-top: 2rem;
+        color: var(--dark-700);
+        text-align: center;
     }
 </style>

--- a/tests/fixtures/context-page.ts
+++ b/tests/fixtures/context-page.ts
@@ -5,11 +5,13 @@ export class ContextPageFixture {
     public title: Locator;
     public count: Locator;
     public tasks: Locator;
+    public noTasks: Locator
 
     constructor(public readonly page: Page, public readonly viewport?: ViewportSize | null) {
         this.layout = this.page.getByTestId('context-layout');
         this.title = this.layout.getByTestId('context-title');
         this.count = this.layout.getByTestId('tasks-count');
         this.tasks = this.layout.locator('.task-container');
+        this.noTasks = this.layout.getByTestId('no-tasks');
     }
 }

--- a/tests/tasks/read.test.ts
+++ b/tests/tasks/read.test.ts
@@ -7,6 +7,35 @@ import { ContextPageFixture } from "../fixtures/context-page";
 import { TaskFixture } from "../fixtures/task";
 
 test.describe('tasks - read', () => {
+    test('should display messaging when no tasks are found', async ({ page, viewport, database }) => {
+        const email = getEmail();
+        const password = 'Password123!';
+
+        const signup = new SignUpFixture(page);
+        const nav = new NavFixture(page, viewport);
+        const inbox = new ContextPageFixture(page, viewport);
+
+        await page.goto('/');
+
+        await signup.signUp({ email, password, confirmPassword: password });
+
+        await page.waitForURL('/dashboard', {waitUntil: 'networkidle'});
+
+        await nav.openMobileNav();
+        await nav.contextLinks.inbox.click({ force: true });
+
+        await page.waitForURL('/inbox', {waitUntil: 'networkidle'});
+
+        await expect(inbox.layout).toBeVisible();
+        await expect(inbox.title).toHaveText('Inbox');
+        await expect(inbox.count).toHaveText(`${0} tasks`);
+        await expect(inbox.tasks).toHaveCount(0);
+        await expect(inbox.noTasks).toBeVisible();
+        await expect(inbox.noTasks).toHaveText('No tasks found');
+
+        await signup.cleanup(email, database);
+    });
+
     test('should display all tasks for the current context', async ({ page, viewport, database }) => {
         const email = getEmail();
         const password = 'Password123!';


### PR DESCRIPTION
Resolves #121 

Adds no tasks state to context pages when no tasks are found in that context.