### PR TITLE
refactor: updates csp for both (blank) and (app) with new connect-src

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -25,8 +25,8 @@
                 default-src 'self' 'unsafe-inline';
                 style-src 'self' 'unsafe-inline';
                 font-src 'self'; 
-                connect-src https://ohmygtd.app ws://ohmygtd.app https://api.unisvg.com/ *.sentry.io blob:; 
-                img-src https://ohmygtd.app blob:; 
+                connect-src https://ohmygtd.wraithcode.io ws://ohmygtd.wraithcode.io https://api.unisvg.com https://*.sentry.io https://*.ingest.sentry.io blob:; 
+                img-src https://ohmygtd.wraithcode.io blob:; 
                 child-src blob:; 
                 worker-src blob:;"
         />
@@ -39,7 +39,7 @@
                 default-src 'self' 'unsafe-inline';
                 style-src 'self' 'unsafe-inline';
                 font-src 'self'; 
-                connect-src http://localhost:5173 http://localhost:4173 ws://localhost:5173 ws://localhost:4173 https://api.unisvg.com/ *.sentry.io blob:; 
+                connect-src http://localhost:5173 http://localhost:4173 ws://localhost:5173 ws://localhost:4173 https://api.unisvg.com https://*.sentry.io https://*.ingest.sentry.io blob:; 
                 img-src http://localhost:5173 http://localhost:4173 blob:; 
                 child-src blob:; 
                 worker-src blob:;"

--- a/src/routes/(blank)/+layout.svelte
+++ b/src/routes/(blank)/+layout.svelte
@@ -20,7 +20,7 @@
                 default-src 'self' 'unsafe-inline';
                 style-src 'self' 'unsafe-inline';
                 font-src 'self'; 
-                connect-src https://ohmygtd.wraithcode.io ws://ohmygtd.wraithcode.io https://api.unisvg.com/ *.sentry.io blob:; 
+                connect-src https://ohmygtd.wraithcode.io ws://ohmygtd.wraithcode.io https://api.unisvg.com https://*.sentry.io https://*.ingest.sentry.io blob:; 
                 img-src https://ohmygtd.wraithcode.io blob:; 
                 child-src blob:; 
                 worker-src blob:;"
@@ -34,7 +34,7 @@
                 default-src 'self' 'unsafe-inline';
                 style-src 'self' 'unsafe-inline';
                 font-src 'self'; 
-                connect-src http://localhost:5173 http://localhost:4173 ws://localhost:5173 ws://localhost:4173 https://api.unisvg.com/ *.sentry.io blob:; 
+                connect-src http://localhost:5173 http://localhost:4173 ws://localhost:5173 ws://localhost:4173 https://api.unisvg.com https://*.sentry.io https://*.ingest.sentry.io blob:; 
                 img-src http://localhost:5173 http://localhost:4173 blob:; 
                 child-src blob:; 
                 worker-src blob:;"


### PR DESCRIPTION
Resolves #168 

removes `https://oymygtd.app` and adds `https://ohmygtd.wraithcode.app` and `https://*.ingenst.sentry.io` to connect-src of Content Security Policy.

